### PR TITLE
add paging to ldap search

### DIFF
--- a/sync_ldap_groups_to_svn_authz.py
+++ b/sync_ldap_groups_to_svn_authz.py
@@ -544,7 +544,7 @@ def load_cli_properties(parser):
   group_query = options.group_query
   group_dns = options.group_dns
   group_member_attribute = options.group_member_attribute
-  ldap_protocol_version = options.lda_protocol_version
+  ldap_protocol_version = options.ldap_protocol_version
   user_query = options.user_query
   userid_attribute = options.userid_attribute
   followgroups = options.followgroups


### PR DESCRIPTION
on larger directories, a single-query can exceed the size limit of a
single search, giving the errorr (SIZE_EXCEEDED).

This commit changes the ldap search to use paging, whereas multiple
search requests of a default size of 1000 results are made.

This was created with inspiration from the following sources:
 - https://gist.github.com/mattfahrner/c228ead9c516fc322d3a
 - https://bitbucket.org/jaraco/python-ldap/src/f208b6338a28/Demo/paged_search_ext_s.py?fileviewer=file-view-default